### PR TITLE
Fix plotting behavior when displaying

### DIFF
--- a/lendres/plotting/LegendHelper.py
+++ b/lendres/plotting/LegendHelper.py
@@ -10,7 +10,7 @@ class LegendHelper():
 
 
     @classmethod
-    def CreateLegendAtFigureBottom(cls, figure:matplotlib.figure.Figure, axes:matplotlib.axes.Axes, offset=0.15, legendOptions:LegendOptions=LegendOptions()):
+    def CreateLegendAtFigureBottom(cls, figure:matplotlib.figure.Figure, axes:matplotlib.axes.Axes, offset=0.15, legendOptions:LegendOptions=LegendOptions(), bottomPercentage: float = None):
         legend = None
 
         if legendOptions is not None:
@@ -18,6 +18,9 @@ class LegendHelper():
         
             if legendOptions.ChangeLineWidths:
                 cls.SetLegendLineWidths(legend, legendOptions.lineWidth)
+
+            if bottomPercentage is not None:
+                figure.subplots_adjust(bottom=bottomPercentage)
 
         return legend
 

--- a/lendres/plotting/default.mplstyle
+++ b/lendres/plotting/default.mplstyle
@@ -2,7 +2,7 @@
 # @author: Lance A. Endres
 
 figure.figsize         : 10, 6
-figure.dpi             : 300
+figure.dpi             : 100
 font.size              : 20
 font.weight            : bold
 figure.titlesize       : 24


### PR DESCRIPTION
Fixes in two places.

1. Modified the DPI in the default matplotlib style file.
2. Implemented argument for `LegendHelper.CreateLegendAtFigureBottom` that sets the percentage of the figure (from the bottom) allocated to the legend.

For item 1, we can further investigate whether to modify this in the rest of the style files that are available as well.
For item 2, we can implement this as a default option (tentatively setting to 0.2). Leaving it optional for now to avoid breaking any other code.